### PR TITLE
style: apply gofmt and add cardinality processor tests

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -37,18 +37,18 @@ func main() {
 	// DisableClickHouse=true 이면 인메모리 링버퍼로 fallback한다.
 	// 프로덕션에서는 DISABLE_CLICKHOUSE=false (기본값)로 ClickHouse를 사용한다.
 	var (
-		traceStore      store.TraceStore
-		metricStore     store.MetricStore
-		logStore        store.LogStore
-		chConn          driver.Conn                  // ClickHouse 공유 커넥션 (RCA Engine 등에서 재사용)
-		catalogStore         *store.ServiceCatalogStore    // Gap 4: 서비스 카탈로그
-		errorGroupStore      *store.ErrorGroupStore        // Gap 2: 에러 그룹 집계
-		sloStore             *store.SLOStore               // Gap 3: SLO/SLI + Burn-Rate
-		rcaStore             *store.RCAStore               // P1: RCA 결과 조회
-		deploymentEventStore *store.DeploymentEventStore   // GAP-04: 배포 이벤트 상관 분석
-		logAnalyticsStore    *store.LogAnalyticsStore      // GAP-06: Log Analytics
-		profilingStore       *store.ProfilingStore         // GAP-07: Continuous Profiling
-		k8sPodMetricsStore   *store.K8sPodMetricsStore    // GAP-08 확장: K8s Pod 리소스 메트릭
+		traceStore           store.TraceStore
+		metricStore          store.MetricStore
+		logStore             store.LogStore
+		chConn               driver.Conn                 // ClickHouse 공유 커넥션 (RCA Engine 등에서 재사용)
+		catalogStore         *store.ServiceCatalogStore  // Gap 4: 서비스 카탈로그
+		errorGroupStore      *store.ErrorGroupStore      // Gap 2: 에러 그룹 집계
+		sloStore             *store.SLOStore             // Gap 3: SLO/SLI + Burn-Rate
+		rcaStore             *store.RCAStore             // P1: RCA 결과 조회
+		deploymentEventStore *store.DeploymentEventStore // GAP-04: 배포 이벤트 상관 분석
+		logAnalyticsStore    *store.LogAnalyticsStore    // GAP-06: Log Analytics
+		profilingStore       *store.ProfilingStore       // GAP-07: Continuous Profiling
+		k8sPodMetricsStore   *store.K8sPodMetricsStore   // GAP-08 확장: K8s Pod 리소스 메트릭
 	)
 
 	if cfg.DisableClickHouse {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,17 +198,17 @@ type Config struct {
 	//   logs        → [log-rag-embedder]        → EmbedPipeline → Qdrant (ERROR+만)
 	//
 	// false이면 기존 채널 기반 직접 적재(DirectSpanPublisher)로 동작한다.
-	KafkaEnabled              bool
-	KafkaBrokers              []string // 콤마 구분 브로커 목록 (KAFKA_BROKERS, 기본 "localhost:9092")
-	KafkaTopic                string   // span 이벤트 토픽 (KAFKA_TOPIC, 기본 "spans.error")
-	KafkaMetricsTopic         string   // metric 이벤트 토픽 (KAFKA_METRICS_TOPIC, 기본 "metrics")
-	KafkaLogsTopic            string   // log 이벤트 토픽 (KAFKA_LOGS_TOPIC, 기본 "logs")
-	KafkaDeployTopic          string   // 배포 이벤트 토픽 (KAFKA_DEPLOY_TOPIC, 기본 "deploys")
-	KafkaRAGGroup             string   // span RAG consumer group (KAFKA_RAG_GROUP, 기본 "rag-embedder")
-	KafkaForecastGroup        string   // span Forecast consumer group (KAFKA_FORECAST_GROUP, 기본 "forecast-feeder")
-	KafkaMetricForecastGroup  string   // metric Forecast consumer group (KAFKA_METRIC_FORECAST_GROUP, 기본 "metric-forecast-feeder")
-	KafkaLogRAGGroup          string   // log RAG consumer group (KAFKA_LOG_RAG_GROUP, 기본 "log-rag-embedder")
-	KafkaForecastEndpoint     string   // Forecast 서버 URL (KAFKA_FORECAST_ENDPOINT, 빈 문자열이면 stub)
+	KafkaEnabled             bool
+	KafkaBrokers             []string // 콤마 구분 브로커 목록 (KAFKA_BROKERS, 기본 "localhost:9092")
+	KafkaTopic               string   // span 이벤트 토픽 (KAFKA_TOPIC, 기본 "spans.error")
+	KafkaMetricsTopic        string   // metric 이벤트 토픽 (KAFKA_METRICS_TOPIC, 기본 "metrics")
+	KafkaLogsTopic           string   // log 이벤트 토픽 (KAFKA_LOGS_TOPIC, 기본 "logs")
+	KafkaDeployTopic         string   // 배포 이벤트 토픽 (KAFKA_DEPLOY_TOPIC, 기본 "deploys")
+	KafkaRAGGroup            string   // span RAG consumer group (KAFKA_RAG_GROUP, 기본 "rag-embedder")
+	KafkaForecastGroup       string   // span Forecast consumer group (KAFKA_FORECAST_GROUP, 기본 "forecast-feeder")
+	KafkaMetricForecastGroup string   // metric Forecast consumer group (KAFKA_METRIC_FORECAST_GROUP, 기본 "metric-forecast-feeder")
+	KafkaLogRAGGroup         string   // log RAG consumer group (KAFKA_LOG_RAG_GROUP, 기본 "log-rag-embedder")
+	KafkaForecastEndpoint    string   // Forecast 서버 URL (KAFKA_FORECAST_ENDPOINT, 빈 문자열이면 stub)
 
 	// ── Collector Self-Tracing ────────────────────────────────────────────
 	// SELF_TRACING_ENABLED=true이면 컬렉터 내부 파이프라인(decode/process/store)을
@@ -242,26 +242,26 @@ type Config struct {
 // 필수 항목이 없으면 기본값을 사용하므로 항상 유효한 설정이 반환된다.
 func Load() (*Config, error) {
 	cfg := &Config{
-		GRPCPort:          envInt("GRPC_PORT", 4317),
-		HTTPPort:          envInt("HTTP_PORT", 4318),
-		ClickHouseAddr:    envStr("CLICKHOUSE_ADDR", "localhost:9000"),
-		ClickHouseDB:      envStr("CLICKHOUSE_DB", "apm"),
-		ClickHouseUser:    envStr("CLICKHOUSE_USER", "default"),
-		ClickHousePassword: envStr("CLICKHOUSE_PASSWORD", ""),
-		BatchSize:         envInt("BATCH_SIZE", 1000),
-		FlushInterval:     envDuration("FLUSH_INTERVAL", 2*time.Second),
-		ChannelBufferSize: envInt("CHANNEL_BUFFER_SIZE", 8192),
-		MemoryBufferSize:  envInt("MEMORY_BUFFER_SIZE", 10000),
-		DisableClickHouse:        envBool("DISABLE_CLICKHOUSE", false),
-		SamplingEnabled:          envBool("SAMPLING_ENABLED", false),
-		RemoteConfigURL:          envStr("REMOTE_CONFIG_URL", ""),
-		RemoteConfigPollInterval: envDuration("REMOTE_CONFIG_POLL_INTERVAL", 30*time.Second),
-		RetentionDays:            envInt("RETENTION_DAYS", 30),
-		EmbedEnabled:             envBool("EMBED_ENABLED", true),
-		EmbedEndpoint:            envStr("EMBED_ENDPOINT", "http://localhost:11434"),
-		EmbedModel:               envStr("EMBED_MODEL", "nomic-embed-text"),
-		QdrantEndpoint:           envStr("QDRANT_ENDPOINT", "http://localhost:6333"),
-		QdrantCollection:         envStr("QDRANT_COLLECTION", "apm_errors"),
+		GRPCPort:                  envInt("GRPC_PORT", 4317),
+		HTTPPort:                  envInt("HTTP_PORT", 4318),
+		ClickHouseAddr:            envStr("CLICKHOUSE_ADDR", "localhost:9000"),
+		ClickHouseDB:              envStr("CLICKHOUSE_DB", "apm"),
+		ClickHouseUser:            envStr("CLICKHOUSE_USER", "default"),
+		ClickHousePassword:        envStr("CLICKHOUSE_PASSWORD", ""),
+		BatchSize:                 envInt("BATCH_SIZE", 1000),
+		FlushInterval:             envDuration("FLUSH_INTERVAL", 2*time.Second),
+		ChannelBufferSize:         envInt("CHANNEL_BUFFER_SIZE", 8192),
+		MemoryBufferSize:          envInt("MEMORY_BUFFER_SIZE", 10000),
+		DisableClickHouse:         envBool("DISABLE_CLICKHOUSE", false),
+		SamplingEnabled:           envBool("SAMPLING_ENABLED", false),
+		RemoteConfigURL:           envStr("REMOTE_CONFIG_URL", ""),
+		RemoteConfigPollInterval:  envDuration("REMOTE_CONFIG_POLL_INTERVAL", 30*time.Second),
+		RetentionDays:             envInt("RETENTION_DAYS", 30),
+		EmbedEnabled:              envBool("EMBED_ENABLED", true),
+		EmbedEndpoint:             envStr("EMBED_ENDPOINT", "http://localhost:11434"),
+		EmbedModel:                envStr("EMBED_MODEL", "nomic-embed-text"),
+		QdrantEndpoint:            envStr("QDRANT_ENDPOINT", "http://localhost:6333"),
+		QdrantCollection:          envStr("QDRANT_COLLECTION", "apm_errors"),
 		RAGScoreThreshold:         envFloat64("RAG_SCORE_THRESHOLD", 0.65),
 		RAGSlowThresholdMs:        envInt("RAG_SLOW_THRESHOLD_MS", 1000),
 		RAGBackfillEnabled:        envBool("RAG_BACKFILL_ENABLED", true),
@@ -274,57 +274,57 @@ func Load() (*Config, error) {
 		LLMModel:                  envStr("LLM_MODEL", "qwen2.5:3b"),
 		BackupEnabled:             envBool("BACKUP_ENABLED", true),
 		BackupDir:                 envStr("BACKUP_DIR", "./backup"),
-		DLQDir:                   envStr("DLQ_DIR", "./dlq"),
-		DLQRetentionDays:         envInt("DLQ_RETENTION_DAYS", 7),
-		DLQReplayInterval:        envDuration("DLQ_REPLAY_INTERVAL", 5*time.Minute),
-		CBFailureThreshold:       envInt("CB_FAILURE_THRESHOLD", 5),
-		CBCooldown:               envDuration("CB_COOLDOWN", 60*time.Second),
-		FlushWorkers:             envInt("FLUSH_WORKERS", 2),
-		SelfURL:                  envStr("SELF_URL", ""),
-		PeerURLs:                 envStringSlice("PEER_URLS", nil),
-		PeerCBFailureThreshold:   envInt("PEER_CB_FAILURE_THRESHOLD", 5),
-		PeerCBCooldown:           envDuration("PEER_CB_COOLDOWN", 30*time.Second),
-		BaselineEnabled:          envBool("BASELINE_ENABLED", true),
-		BaselineInterval:         envDuration("BASELINE_INTERVAL", time.Hour),
-		AnomalyEnabled:           envBool("ANOMALY_ENABLED", true),
-		AnomalyInterval:          envDuration("ANOMALY_INTERVAL", time.Minute),
-		AnomalyTrainInterval:     envDuration("ANOMALY_TRAIN_INTERVAL", 6*time.Hour),
-		AnomalyNTrees:            envInt("ANOMALY_N_TREES", 100),
-		AnomalyMaxSamples:        envInt("ANOMALY_MAX_SAMPLES", 256),
-		AnomalyZWarn:             envFloat64("ANOMALY_Z_WARN", 2.0),
-		AnomalyZCritical:         envFloat64("ANOMALY_Z_CRITICAL", 3.0),
-		AnomalyIFThreshold:       envFloat64("ANOMALY_IF_THRESHOLD", 0.65),
-		RCAEnabled:               envBool("RCA_ENABLED", true),
-		RCAInterval:              envDuration("RCA_INTERVAL", 2*time.Minute),
-		AlertWebhookURL:          envStr("ALERT_WEBHOOK_URL", ""),
-		AlertSlackWebhookURL:     envStr("ALERT_SLACK_WEBHOOK_URL", ""),
-		AlertInterval:            envDuration("ALERT_INTERVAL", time.Minute),
-		AlertMinSeverity:         envStr("ALERT_MIN_SEVERITY", "warning"),
-		HotReloadFile:            envStr("HOT_RELOAD_FILE", ""),
-		HotReloadInterval:        envDuration("HOT_RELOAD_INTERVAL", 30*time.Second),
-		CardinalityEnabled:       envBool("CARDINALITY_ENABLED", false),
-		CardinalityLimit:         envInt("CARDINALITY_LIMIT", 200),
-		CardinalityBloomBits:     envInt("CARDINALITY_BLOOM_BITS", 100_000),
-		CardinalityBloomK:        envInt("CARDINALITY_BLOOM_K", 4),
-		SelfTracingEnabled:       envBool("SELF_TRACING_ENABLED", false),
-		ForecastEndpoint:         envStr("FORECAST_ENDPOINT", ""),
-		ForecastBatchSize:        envInt("FORECAST_BATCH_SIZE", 100),
-		ForecastFlushInterval:    envDuration("FORECAST_FLUSH_INTERVAL", 5*time.Second),
-		KafkaEnabled:             envBool("KAFKA_ENABLED", false),
-		KafkaBrokers:             envStringSlice("KAFKA_BROKERS", []string{"localhost:9092"}),
-		KafkaTopic:               envStr("KAFKA_TOPIC", "spans.error"),
-		KafkaMetricsTopic:        envStr("KAFKA_METRICS_TOPIC", "metrics"),
-		KafkaLogsTopic:           envStr("KAFKA_LOGS_TOPIC", "logs"),
-		KafkaDeployTopic:         envStr("KAFKA_DEPLOY_TOPIC", "deploys"),
-		KafkaRAGGroup:            envStr("KAFKA_RAG_GROUP", "rag-embedder"),
-		KafkaForecastGroup:       envStr("KAFKA_FORECAST_GROUP", "forecast-feeder"),
-		KafkaMetricForecastGroup: envStr("KAFKA_METRIC_FORECAST_GROUP", "metric-forecast-feeder"),
-		KafkaLogRAGGroup:         envStr("KAFKA_LOG_RAG_GROUP", "log-rag-embedder"),
-		KafkaForecastEndpoint:    envStr("KAFKA_FORECAST_ENDPOINT", ""),
-		SamplingConfigJSON:       envStr("SAMPLING_CONFIG_JSON", ""),
-		APIKey:                   envStr("API_KEY", ""),
-		WALDir:      envStr("WAL_DIR", "./wal"),
-		WALMaxBytes: int64(envInt("WAL_MAX_BYTES", 64<<20)),
+		DLQDir:                    envStr("DLQ_DIR", "./dlq"),
+		DLQRetentionDays:          envInt("DLQ_RETENTION_DAYS", 7),
+		DLQReplayInterval:         envDuration("DLQ_REPLAY_INTERVAL", 5*time.Minute),
+		CBFailureThreshold:        envInt("CB_FAILURE_THRESHOLD", 5),
+		CBCooldown:                envDuration("CB_COOLDOWN", 60*time.Second),
+		FlushWorkers:              envInt("FLUSH_WORKERS", 2),
+		SelfURL:                   envStr("SELF_URL", ""),
+		PeerURLs:                  envStringSlice("PEER_URLS", nil),
+		PeerCBFailureThreshold:    envInt("PEER_CB_FAILURE_THRESHOLD", 5),
+		PeerCBCooldown:            envDuration("PEER_CB_COOLDOWN", 30*time.Second),
+		BaselineEnabled:           envBool("BASELINE_ENABLED", true),
+		BaselineInterval:          envDuration("BASELINE_INTERVAL", time.Hour),
+		AnomalyEnabled:            envBool("ANOMALY_ENABLED", true),
+		AnomalyInterval:           envDuration("ANOMALY_INTERVAL", time.Minute),
+		AnomalyTrainInterval:      envDuration("ANOMALY_TRAIN_INTERVAL", 6*time.Hour),
+		AnomalyNTrees:             envInt("ANOMALY_N_TREES", 100),
+		AnomalyMaxSamples:         envInt("ANOMALY_MAX_SAMPLES", 256),
+		AnomalyZWarn:              envFloat64("ANOMALY_Z_WARN", 2.0),
+		AnomalyZCritical:          envFloat64("ANOMALY_Z_CRITICAL", 3.0),
+		AnomalyIFThreshold:        envFloat64("ANOMALY_IF_THRESHOLD", 0.65),
+		RCAEnabled:                envBool("RCA_ENABLED", true),
+		RCAInterval:               envDuration("RCA_INTERVAL", 2*time.Minute),
+		AlertWebhookURL:           envStr("ALERT_WEBHOOK_URL", ""),
+		AlertSlackWebhookURL:      envStr("ALERT_SLACK_WEBHOOK_URL", ""),
+		AlertInterval:             envDuration("ALERT_INTERVAL", time.Minute),
+		AlertMinSeverity:          envStr("ALERT_MIN_SEVERITY", "warning"),
+		HotReloadFile:             envStr("HOT_RELOAD_FILE", ""),
+		HotReloadInterval:         envDuration("HOT_RELOAD_INTERVAL", 30*time.Second),
+		CardinalityEnabled:        envBool("CARDINALITY_ENABLED", false),
+		CardinalityLimit:          envInt("CARDINALITY_LIMIT", 200),
+		CardinalityBloomBits:      envInt("CARDINALITY_BLOOM_BITS", 100_000),
+		CardinalityBloomK:         envInt("CARDINALITY_BLOOM_K", 4),
+		SelfTracingEnabled:        envBool("SELF_TRACING_ENABLED", false),
+		ForecastEndpoint:          envStr("FORECAST_ENDPOINT", ""),
+		ForecastBatchSize:         envInt("FORECAST_BATCH_SIZE", 100),
+		ForecastFlushInterval:     envDuration("FORECAST_FLUSH_INTERVAL", 5*time.Second),
+		KafkaEnabled:              envBool("KAFKA_ENABLED", false),
+		KafkaBrokers:              envStringSlice("KAFKA_BROKERS", []string{"localhost:9092"}),
+		KafkaTopic:                envStr("KAFKA_TOPIC", "spans.error"),
+		KafkaMetricsTopic:         envStr("KAFKA_METRICS_TOPIC", "metrics"),
+		KafkaLogsTopic:            envStr("KAFKA_LOGS_TOPIC", "logs"),
+		KafkaDeployTopic:          envStr("KAFKA_DEPLOY_TOPIC", "deploys"),
+		KafkaRAGGroup:             envStr("KAFKA_RAG_GROUP", "rag-embedder"),
+		KafkaForecastGroup:        envStr("KAFKA_FORECAST_GROUP", "forecast-feeder"),
+		KafkaMetricForecastGroup:  envStr("KAFKA_METRIC_FORECAST_GROUP", "metric-forecast-feeder"),
+		KafkaLogRAGGroup:          envStr("KAFKA_LOG_RAG_GROUP", "log-rag-embedder"),
+		KafkaForecastEndpoint:     envStr("KAFKA_FORECAST_ENDPOINT", ""),
+		SamplingConfigJSON:        envStr("SAMPLING_CONFIG_JSON", ""),
+		APIKey:                    envStr("API_KEY", ""),
+		WALDir:                    envStr("WAL_DIR", "./wal"),
+		WALMaxBytes:               int64(envInt("WAL_MAX_BYTES", 64<<20)),
 	}
 	// WAL_ENABLED 환경변수가 명시되지 않으면 DISABLE_CLICKHOUSE 값을 따른다.
 	if walEnv := os.Getenv("WAL_ENABLED"); walEnv != "" {

--- a/internal/decoder/decoder_test.go
+++ b/internal/decoder/decoder_test.go
@@ -4,10 +4,10 @@ import (
 	"encoding/hex"
 	"testing"
 
-	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	collectorlogsv1 "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	collectormetricsv1 "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	collectortracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	logsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
 	metricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
@@ -323,9 +323,9 @@ func TestDecodeMetrics_Gauge(t *testing.T) {
 									Gauge: &metricsv1.Gauge{
 										DataPoints: []*metricsv1.NumberDataPoint{
 											{
-												Attributes:  []*commonv1.KeyValue{strKV("area", "heap")},
+												Attributes:   []*commonv1.KeyValue{strKV("area", "heap")},
 												TimeUnixNano: 1_000_000_000,
-												Value: &metricsv1.NumberDataPoint_AsDouble{AsDouble: 52428800},
+												Value:        &metricsv1.NumberDataPoint_AsDouble{AsDouble: 52428800},
 											},
 										},
 									},

--- a/internal/ingester/ingester.go
+++ b/internal/ingester/ingester.go
@@ -105,11 +105,11 @@ type Ingester struct {
 	traceStore  store.TraceStore
 	metricStore store.MetricStore
 	logStore    store.LogStore
-	spanPub     SpanPublisher          // nil이면 span RAG/Forecast 비활성화
-	metricPub   MetricPublisher        // nil이면 metric Forecast 비활성화
-	logPub      LogPublisher           // nil이면 log RAG 비활성화
-	pipeline    *processor.Pipeline    // nil이면 프로세서 파이프라인 비활성화
-	selfTracer  *selftracing.Tracer    // nil이면 셀프 트레이싱 비활성화
+	spanPub     SpanPublisher       // nil이면 span RAG/Forecast 비활성화
+	metricPub   MetricPublisher     // nil이면 metric Forecast 비활성화
+	logPub      LogPublisher        // nil이면 log RAG 비활성화
+	pipeline    *processor.Pipeline // nil이면 프로세서 파이프라인 비활성화
+	selfTracer  *selftracing.Tracer // nil이면 셀프 트레이싱 비활성화
 
 	// atomic 카운터: /api/collector/stats 조회용 (단조 증가, reset 없음)
 	traceReceived  atomic.Int64

--- a/internal/model/metric.go
+++ b/internal/model/metric.go
@@ -23,7 +23,7 @@ type DataPoint struct {
 	BucketCounts   []uint64       `json:"bucketCounts,omitempty"`
 	// ExplicitBounds는 Histogram의 bucket 경계값 (len = len(BucketCounts) - 1)
 	// e.g., [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
-	ExplicitBounds []float64 `json:"explicitBounds,omitempty"`
+	ExplicitBounds []float64  `json:"explicitBounds,omitempty"`
 	Exemplars      []Exemplar `json:"exemplars,omitempty"`
 }
 
@@ -38,12 +38,12 @@ type Exemplar struct {
 
 // MetricData는 OTLP metrics에서 추출한 단일 metric을 나타낸다.
 type MetricData struct {
-	Name         string     `json:"name"`
-	Description  string     `json:"description"`
-	Unit         string     `json:"unit"`
-	Type         MetricType `json:"metricType"`
+	Name         string      `json:"name"`
+	Description  string      `json:"description"`
+	Unit         string      `json:"unit"`
+	Type         MetricType  `json:"metricType"`
 	DataPoints   []DataPoint `json:"dataPoints"`
-	ServiceName  string     `json:"serviceName"`
-	ScopeName    string     `json:"scopeName"`
-	ReceivedAtMs int64      `json:"receivedAtMs"`
+	ServiceName  string      `json:"serviceName"`
+	ScopeName    string      `json:"scopeName"`
+	ReceivedAtMs int64       `json:"receivedAtMs"`
 }

--- a/internal/model/span.go
+++ b/internal/model/span.go
@@ -27,10 +27,10 @@ type SpanData struct {
 	ReceivedAtMs  int64          `json:"receivedAtMs"`
 	// W3C Trace State: span 컨텍스트에 포함된 벤더별 트레이싱 메타데이터.
 	// OTLP Span.trace_state 필드에서 추출된다.
-	TraceState string     `json:"traceState,omitempty"`
+	TraceState string `json:"traceState,omitempty"`
 	// Links: 다른 Trace/Span에 대한 크로스-트레이스 연결 목록.
 	// OTLP Span.links 필드에서 추출된다.
-	Links      []SpanLink `json:"links,omitempty"`
+	Links []SpanLink `json:"links,omitempty"`
 }
 
 // DurationNano는 span의 소요 시간을 나노초로 반환한다.

--- a/internal/processor/cardinality_test.go
+++ b/internal/processor/cardinality_test.go
@@ -1,0 +1,143 @@
+package processor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kkc/javi-collector/internal/model"
+)
+
+func TestBloomFilterAddTest(t *testing.T) {
+	bf := newBloomFilter(10_000, 4)
+
+	if bf.test("alpha") {
+		t.Fatal("test on empty filter should return false")
+	}
+	if isNew := bf.add("alpha"); !isNew {
+		t.Fatal("first add should report isNew=true")
+	}
+	if !bf.test("alpha") {
+		t.Fatal("test after add should return true")
+	}
+	if isNew := bf.add("alpha"); isNew {
+		t.Fatal("re-adding the same value should report isNew=false")
+	}
+	if bf.n != 1 {
+		t.Fatalf("estimated unique count = %d, want 1", bf.n)
+	}
+}
+
+func TestAttrTrackerRespectsLimit(t *testing.T) {
+	at := newAttrTracker(10_000, 4, 2)
+
+	if !at.allow("v1") {
+		t.Fatal("first distinct value should be allowed")
+	}
+	if !at.allow("v2") {
+		t.Fatal("second distinct value should be allowed (at limit boundary)")
+	}
+	if at.allow("v3") {
+		t.Fatal("third distinct value should be blocked (over limit)")
+	}
+	// Previously seen values must still pass through after the limit is hit.
+	if !at.allow("v1") {
+		t.Fatal("previously seen value should still be allowed")
+	}
+	if at.drops != 1 {
+		t.Fatalf("drops = %d, want 1", at.drops)
+	}
+}
+
+func TestCardinalityProcessorReplacesHighCardinality(t *testing.T) {
+	limits := CardinalityLimits{PerServiceAttrLimit: 2, BloomFilterBits: 10_000, BloomHashFunctions: 4}
+	cp := NewCardinalityProcessor(limits)
+
+	spans := make([]*model.SpanData, 0, 4)
+	for _, id := range []string{"u1", "u2", "u3", "u4"} {
+		spans = append(spans, &model.SpanData{
+			ServiceName: "svc",
+			Attributes:  map[string]any{"user_id": id},
+		})
+	}
+
+	out, err := cp.ProcessSpans(context.Background(), spans)
+	if err != nil {
+		t.Fatalf("ProcessSpans error: %v", err)
+	}
+
+	// First two distinct values pass; the rest are replaced with the placeholder.
+	want := []string{"u1", "u2", cardinalityPlaceholder, cardinalityPlaceholder}
+	for i, sp := range out {
+		if got := sp.Attributes["user_id"]; got != want[i] {
+			t.Errorf("span[%d] user_id = %q, want %q", i, got, want[i])
+		}
+	}
+}
+
+func TestCardinalityProcessorIgnoresNonString(t *testing.T) {
+	cp := NewCardinalityProcessor(CardinalityLimits{PerServiceAttrLimit: 1, BloomFilterBits: 1000, BloomHashFunctions: 4})
+
+	spans := []*model.SpanData{
+		{ServiceName: "svc", Attributes: map[string]any{"count": 1}},
+		{ServiceName: "svc", Attributes: map[string]any{"count": 2}},
+		{ServiceName: "svc", Attributes: map[string]any{"count": 3}},
+	}
+
+	out, _ := cp.ProcessSpans(context.Background(), spans)
+	for i, sp := range out {
+		if _, replaced := sp.Attributes["count"].(string); replaced {
+			t.Errorf("span[%d]: non-string value must never be replaced, got %v", i, sp.Attributes["count"])
+		}
+	}
+}
+
+func TestCardinalityProcessorIsolatesServiceAndKey(t *testing.T) {
+	cp := NewCardinalityProcessor(CardinalityLimits{PerServiceAttrLimit: 1, BloomFilterBits: 10_000, BloomHashFunctions: 4})
+
+	// Same value "x" under different (service, key) tuples must each get its own
+	// budget — none should be replaced on first sight.
+	spans := []*model.SpanData{
+		{ServiceName: "a", Attributes: map[string]any{"k1": "x"}},
+		{ServiceName: "b", Attributes: map[string]any{"k1": "x"}},
+		{ServiceName: "a", Attributes: map[string]any{"k2": "x"}},
+	}
+
+	out, _ := cp.ProcessSpans(context.Background(), spans)
+	for i, sp := range out {
+		for k, v := range sp.Attributes {
+			if v == cardinalityPlaceholder {
+				t.Errorf("span[%d] key %q wrongly replaced; trackers must be isolated per (service,key)", i, k)
+			}
+		}
+	}
+}
+
+func TestCardinalityProcessorMetricsAndLogs(t *testing.T) {
+	cp := NewCardinalityProcessor(CardinalityLimits{PerServiceAttrLimit: 1, BloomFilterBits: 10_000, BloomHashFunctions: 4})
+
+	metrics := []*model.MetricData{
+		{ServiceName: "svc", DataPoints: []model.DataPoint{
+			{Attributes: map[string]any{"region": "r1"}},
+			{Attributes: map[string]any{"region": "r2"}},
+		}},
+	}
+	mOut, err := cp.ProcessMetrics(context.Background(), metrics)
+	if err != nil {
+		t.Fatalf("ProcessMetrics error: %v", err)
+	}
+	if mOut[0].DataPoints[1].Attributes["region"] != cardinalityPlaceholder {
+		t.Errorf("second metric region should be replaced, got %v", mOut[0].DataPoints[1].Attributes["region"])
+	}
+
+	logs := []*model.LogData{
+		{ServiceName: "svc2", Attributes: map[string]any{"trace": "t1"}},
+		{ServiceName: "svc2", Attributes: map[string]any{"trace": "t2"}},
+	}
+	lOut, err := cp.ProcessLogs(context.Background(), logs)
+	if err != nil {
+		t.Fatalf("ProcessLogs error: %v", err)
+	}
+	if lOut[1].Attributes["trace"] != cardinalityPlaceholder {
+		t.Errorf("second log trace should be replaced, got %v", lOut[1].Attributes["trace"])
+	}
+}

--- a/internal/sampling/policy_test.go
+++ b/internal/sampling/policy_test.go
@@ -73,7 +73,7 @@ func TestEvaluate_ProbabilisticSampling_BoundaryRates(t *testing.T) {
 
 	// Rate=1.0: float64 overflow 없이 반드시 KEEP
 	cfg1 := &SamplingConfig{
-		Enabled: true,
+		Enabled:               true,
 		ProbabilisticSampling: ProbabilisticSamplingConfig{Enabled: true, Rate: 1.0},
 	}
 	if eval.Evaluate([]*model.SpanData{{TraceID: traceID}}, cfg1) != DecisionKeep {
@@ -82,7 +82,7 @@ func TestEvaluate_ProbabilisticSampling_BoundaryRates(t *testing.T) {
 
 	// Rate=0.0: 반드시 DROP
 	cfg0 := &SamplingConfig{
-		Enabled: true,
+		Enabled:               true,
 		ProbabilisticSampling: ProbabilisticSamplingConfig{Enabled: true, Rate: 0.0},
 	}
 	if eval.Evaluate([]*model.SpanData{{TraceID: "4bf92f3577b34da60000000000000001"}}, cfg0) != DecisionDrop {

--- a/internal/selftracing/tracer.go
+++ b/internal/selftracing/tracer.go
@@ -145,12 +145,12 @@ func (t *Tracer) emit(sp *model.SpanData) {
 
 // SpanBuilder accumulates span fields and emits on End.
 type SpanBuilder struct {
-	tracer    *Tracer
-	traceID   string
-	spanID    string
-	name      string
-	start     time.Time
-	attrs     map[string]any
+	tracer  *Tracer
+	traceID string
+	spanID  string
+	name    string
+	start   time.Time
+	attrs   map[string]any
 }
 
 // StartSpan begins timing a pipeline operation and returns a SpanBuilder.

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -59,11 +59,11 @@ var (
 // GRPCServer는 OTLP/gRPC 수신 서버다.
 // TraceService, MetricsService, LogsService, Health, Reflection을 단일 grpc.Server에 등록한다.
 type GRPCServer struct {
-	srv         *grpc.Server
-	health      *health.Server
-	ingester    *ingester.Ingester
-	addr        string
-	traceSvc    *traceServiceServer // SetTraceRouter에서 router 주입용
+	srv      *grpc.Server
+	health   *health.Server
+	ingester *ingester.Ingester
+	addr     string
+	traceSvc *traceServiceServer // SetTraceRouter에서 router 주입용
 }
 
 // NewGRPCServer는 OTLP gRPC 서버를 생성하고 서비스를 등록한다.

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -246,7 +246,7 @@ type HTTPServer struct {
 	logStore    store.LogStore
 	srv         *http.Server
 	ready       chan struct{} // close되면 readyz가 200을 반환한다
-	draining    atomic.Bool  // true이면 readyz가 503을 반환한다 (graceful shutdown 드레인)
+	draining    atomic.Bool   // true이면 readyz가 503을 반환한다 (graceful shutdown 드레인)
 
 	// traceRouter는 멀티 인스턴스 Tail Sampling 시 traceID 기반 라우팅을 담당한다.
 	// nil이면 라우팅 비활성화 (단일 인스턴스 또는 Sampling 미사용 배포).

--- a/internal/store/alert_routes.go
+++ b/internal/store/alert_routes.go
@@ -27,13 +27,13 @@ import (
 type AlertRoute struct {
 	ID                 string    `json:"id"`
 	Name               string    `json:"name"`
-	MatchService       string    `json:"match_service"`        // glob 패턴 ("payment-*"), 빈 = 전체
-	MatchSeverity      string    `json:"match_severity"`       // "", "warning", "critical"
-	MatchAnomalyType   string    `json:"match_anomaly_type"`   // "", "latency", "error_rate"
+	MatchService       string    `json:"match_service"`      // glob 패턴 ("payment-*"), 빈 = 전체
+	MatchSeverity      string    `json:"match_severity"`     // "", "warning", "critical"
+	MatchAnomalyType   string    `json:"match_anomaly_type"` // "", "latency", "error_rate"
 	SlackURL           string    `json:"slack_url"`
 	WebhookURL         string    `json:"webhook_url"`
-	Priority           int32     `json:"priority"`              // 낮을수록 높은 우선순위
-	EscalationAfterMin int32     `json:"escalation_after_min"`  // 0 = 에스컬레이션 없음
+	Priority           int32     `json:"priority"`             // 낮을수록 높은 우선순위
+	EscalationAfterMin int32     `json:"escalation_after_min"` // 0 = 에스컬레이션 없음
 	EscalateSlackURL   string    `json:"escalate_slack_url"`
 	EscalateWebhookURL string    `json:"escalate_webhook_url"`
 	Enabled            bool      `json:"enabled"`
@@ -72,12 +72,12 @@ func (r AlertRoute) HasEscalation() bool {
 type AlertEvent struct {
 	ID          string    `json:"id"`
 	AnomalyID   string    `json:"anomaly_id"`
-	RouteID     string    `json:"route_id"`    // 빈 문자열 = 레거시 기본 발송
+	RouteID     string    `json:"route_id"` // 빈 문자열 = 레거시 기본 발송
 	ServiceName string    `json:"service_name"`
 	Severity    string    `json:"severity"`
 	AnomalyType string    `json:"anomaly_type"`
 	FiredAt     time.Time `json:"fired_at"`
-	AckedAt     time.Time `json:"acked_at"`    // zero = ack 안 됨
+	AckedAt     time.Time `json:"acked_at"` // zero = ack 안 됨
 	Escalated   bool      `json:"escalated"`
 }
 

--- a/internal/store/clickhouse.go
+++ b/internal/store/clickhouse.go
@@ -230,7 +230,7 @@ type ClickHouseTraceStore struct {
 	flushCh chan []*model.SpanData // 조립된 배치를 flush worker에 전달하는 큐
 	cfg     ClickHouseConfig
 	dynCfg  atomic.Pointer[storeDynCfg] // 핫 리로드 가능한 배치 설정 (nil이면 cfg 사용)
-	done    chan struct{}                // 모든 flushWorker 종료 시 닫힘
+	done    chan struct{}               // 모든 flushWorker 종료 시 닫힘
 	dlq     *FileBackupWriter           // flush 실패 시 배치 보존 (nil이면 비활성화)
 	cb      *circuitBreaker             // 연속 실패 시 flush 차단 (nil이면 비활성화)
 }
@@ -661,7 +661,7 @@ LIMIT %d`, s.cfg.Database, where, limit)
 }
 
 // QueryBrokenTraces는 root span이 없는 트레이스를 감지한다.
-// traceID 기준으로 집계: parent_span_id=''인 span이 없는 trace = 브로큰 트레이스.
+// traceID 기준으로 집계: parent_span_id가 빈 문자열(empty string)인 span이 없는 trace = 브로큰 트레이스.
 // 계측 미설정, 샘플링 불일치, 또는 네트워크 손실이 원인일 수 있다.
 func (s *ClickHouseTraceStore) QueryBrokenTraces(ctx context.Context, service string, fromMs, toMs int64, limit int) ([]map[string]any, error) {
 	if limit <= 0 {
@@ -789,11 +789,11 @@ LIMIT %d`, s.cfg.Database, where, limit)
 	var result []map[string]any
 	for rows.Next() {
 		var (
-			traceID, spanID, serviceName string
+			traceID, spanID, serviceName   string
 			dbSystem, dbName, dbOp, dbStmt string
-			durationMs                   float64
-			startTime                    time.Time
-			statusCode                   int32
+			durationMs                     float64
+			startTime                      time.Time
+			statusCode                     int32
 		)
 		if err := rows.Scan(&traceID, &spanID, &serviceName,
 			&dbSystem, &dbName, &dbOp, &dbStmt,
@@ -859,16 +859,16 @@ LIMIT 500`, s.cfg.Database), traceID)
 			toMs = endMs
 		}
 		spans = append(spans, map[string]any{
-			"span_id":          spanID,
-			"parent_span_id":   parentSpanID,
-			"service_name":     svc,
-			"span_name":        spanName,
-			"start_ms":         startMs,
-			"duration_ms":      durationMs,
-			"status_code":      statusCode,
-			"exception_type":   excType,
+			"span_id":           spanID,
+			"parent_span_id":    parentSpanID,
+			"service_name":      svc,
+			"span_name":         spanName,
+			"start_ms":          startMs,
+			"duration_ms":       durationMs,
+			"status_code":       statusCode,
+			"exception_type":    excType,
 			"exception_message": excMsg,
-			"http_status_code": httpStatus,
+			"http_status_code":  httpStatus,
 		})
 	}
 	if err := spanRows.Err(); err != nil {
@@ -1395,7 +1395,7 @@ type ClickHouseMetricStore struct {
 	flushCh chan []*model.MetricData // 조립된 배치를 flush worker에 전달하는 큐
 	cfg     ClickHouseConfig
 	dynCfg  atomic.Pointer[storeDynCfg] // 핫 리로드 가능한 배치 설정
-	done    chan struct{}                // 모든 flushWorker 종료 시 닫힘
+	done    chan struct{}               // 모든 flushWorker 종료 시 닫힘
 	dlq     *FileBackupWriter           // flush 실패 시 배치 보존 (nil이면 비활성화)
 	cb      *circuitBreaker             // 연속 실패 시 flush 차단 (nil이면 비활성화)
 }
@@ -1552,9 +1552,9 @@ func (s *ClickHouseMetricStore) QueryMetrics(ctx context.Context, q MetricQuery)
 	var result []*model.MetricData
 	for rows.Next() {
 		var (
-			name, mtype, serviceName string
-			attrsMap                 map[string]string
-			value                    float64
+			name, mtype, serviceName    string
+			attrsMap                    map[string]string
+			value                       float64
 			timestampNano, receivedAtMs int64
 		)
 		if err := rows.Scan(&name, &mtype, &value, &attrsMap, &serviceName, &timestampNano, &receivedAtMs); err != nil {
@@ -1616,12 +1616,12 @@ func (s *ClickHouseMetricStore) QueryMetrics(ctx context.Context, q MetricQuery)
 
 	for hrows.Next() {
 		var (
-			metricName, serviceName string
-			bounds                  []float64
-			bucketCounts            []uint64
-			totalCount              uint64
-			totalSum                float64
-			attrsMap                map[string]string
+			metricName, serviceName     string
+			bounds                      []float64
+			bucketCounts                []uint64
+			totalCount                  uint64
+			totalSum                    float64
+			attrsMap                    map[string]string
 			timestampNano, receivedAtMs int64
 		)
 		if err := hrows.Scan(&metricName, &bounds, &bucketCounts, &totalCount, &totalSum, &attrsMap, &serviceName, &timestampNano, &receivedAtMs); err != nil {
@@ -2054,12 +2054,12 @@ func (s *ClickHouseMetricStore) flushHistogramMetrics(metrics []*model.MetricDat
 
 // ClickHouseLogStore는 LogData를 apm.logs 테이블에 배치 insert한다.
 type ClickHouseLogStore struct {
-	conn    driver.Conn            // 공유 커넥션 풀 (소유권 없음)
-	ch      chan *model.LogData    // 수신 데이터 채널
-	flushCh chan []*model.LogData  // 조립된 배치를 flush worker에 전달하는 큐
+	conn    driver.Conn           // 공유 커넥션 풀 (소유권 없음)
+	ch      chan *model.LogData   // 수신 데이터 채널
+	flushCh chan []*model.LogData // 조립된 배치를 flush worker에 전달하는 큐
 	cfg     ClickHouseConfig
 	dynCfg  atomic.Pointer[storeDynCfg] // 핫 리로드 가능한 배치 설정
-	done    chan struct{}                // 모든 flushWorker 종료 시 닫힘
+	done    chan struct{}               // 모든 flushWorker 종료 시 닫힘
 	dlq     *FileBackupWriter           // flush 실패 시 배치 보존 (nil이면 비활성화)
 	cb      *circuitBreaker             // 연속 실패 시 flush 차단 (nil이면 비활성화)
 }

--- a/internal/store/deployment_events.go
+++ b/internal/store/deployment_events.go
@@ -20,7 +20,7 @@ type DeploymentEvent struct {
 	ID          string    `json:"id"`
 	ServiceName string    `json:"service_name"`
 	Version     string    `json:"version"`
-	Environment string    `json:"environment"`  // "production" | "staging" | "dev"
+	Environment string    `json:"environment"` // "production" | "staging" | "dev"
 	DeployedBy  string    `json:"deployed_by"`
 	Description string    `json:"description"`
 	DeployedAt  time.Time `json:"deployed_at"`

--- a/internal/store/k8s_metrics.go
+++ b/internal/store/k8s_metrics.go
@@ -28,18 +28,18 @@ import (
 
 // K8sPodMetric은 단일 Pod 리소스 메트릭 스냅샷을 나타낸다.
 type K8sPodMetric struct {
-	ServiceName        string    `json:"service_name"`
-	PodName            string    `json:"pod_name"`
-	NodeName           string    `json:"node_name"`
-	Namespace          string    `json:"namespace"`
-	Host               string    `json:"host"`
-	ContainerID        string    `json:"container_id"`
-	CPUUsageMillicore  float64   `json:"cpu_usage_millicore"`
-	CPULimitMillicore  float64   `json:"cpu_limit_millicore"`
-	MemoryUsageBytes   int64     `json:"memory_usage_bytes"`
-	MemoryLimitBytes   int64     `json:"memory_limit_bytes"`
-	MemoryRSSBytes     int64     `json:"memory_rss_bytes"`
-	Timestamp          time.Time `json:"timestamp"`
+	ServiceName       string    `json:"service_name"`
+	PodName           string    `json:"pod_name"`
+	NodeName          string    `json:"node_name"`
+	Namespace         string    `json:"namespace"`
+	Host              string    `json:"host"`
+	ContainerID       string    `json:"container_id"`
+	CPUUsageMillicore float64   `json:"cpu_usage_millicore"`
+	CPULimitMillicore float64   `json:"cpu_limit_millicore"`
+	MemoryUsageBytes  int64     `json:"memory_usage_bytes"`
+	MemoryLimitBytes  int64     `json:"memory_limit_bytes"`
+	MemoryRSSBytes    int64     `json:"memory_rss_bytes"`
+	Timestamp         time.Time `json:"timestamp"`
 }
 
 // K8sPodMetricsStore는 k8s_pod_metrics 테이블 CRUD를 담당한다.
@@ -188,16 +188,16 @@ ORDER BY pod_name`, s.db), service, fromMs, toMs)
 	var result []map[string]any
 	for rows.Next() {
 		var (
-			podName      string
-			nodeName     string
-			namespace    string
-			avgCPU       float64
-			maxCPU       float64
-			limitCPU     float64
-			avgMem       float64
-			maxMem       int64
-			limitMem     int64
-			lastSeen     time.Time
+			podName   string
+			nodeName  string
+			namespace string
+			avgCPU    float64
+			maxCPU    float64
+			limitCPU  float64
+			avgMem    float64
+			maxMem    int64
+			limitMem  int64
+			lastSeen  time.Time
 		)
 		if err := rows.Scan(&podName, &nodeName, &namespace,
 			&avgCPU, &maxCPU, &limitCPU,
@@ -206,16 +206,16 @@ ORDER BY pod_name`, s.db), service, fromMs, toMs)
 			return nil, err
 		}
 		result = append(result, map[string]any{
-			"pod_name":       podName,
-			"node_name":      nodeName,
-			"namespace":      namespace,
-			"avg_cpu_m":      avgCPU,
-			"max_cpu_m":      maxCPU,
-			"cpu_limit_m":    limitCPU,
-			"avg_mem_bytes":  avgMem,
-			"max_mem_bytes":  maxMem,
+			"pod_name":        podName,
+			"node_name":       nodeName,
+			"namespace":       namespace,
+			"avg_cpu_m":       avgCPU,
+			"max_cpu_m":       maxCPU,
+			"cpu_limit_m":     limitCPU,
+			"avg_mem_bytes":   avgMem,
+			"max_mem_bytes":   maxMem,
 			"mem_limit_bytes": limitMem,
-			"last_seen":      lastSeen,
+			"last_seen":       lastSeen,
 		})
 	}
 	return result, rows.Err()

--- a/internal/store/log_analytics.go
+++ b/internal/store/log_analytics.go
@@ -241,7 +241,7 @@ func (s *LogAnalyticsStore) scanSearchRows(ctx context.Context, sql string, args
 
 // LogPattern은 반복 로그 패턴 그룹이다.
 type LogPattern struct {
-	Pattern       string `json:"pattern"`         // 정규화된 body 앞 120자
+	Pattern       string `json:"pattern"` // 정규화된 body 앞 120자
 	SeverityText  string `json:"severity_text"`
 	ServiceName   string `json:"service_name"`
 	Count         uint64 `json:"count"`
@@ -496,4 +496,3 @@ func buildWhereClause(conds []string) string {
 	}
 	return "WHERE " + strings.Join(conds, " AND ")
 }
-

--- a/internal/store/profiling.go
+++ b/internal/store/profiling.go
@@ -25,17 +25,17 @@ import (
 
 // ProfilingSnapshot은 단일 프로파일링 스냅샷을 나타낸다.
 type ProfilingSnapshot struct {
-	ID          string    `json:"id"`
-	ServiceName string    `json:"service_name"`
-	ProfileType string    `json:"profile_type"` // "cpu" | "heap" | "wall" | "alloc"
-	Format      string    `json:"format"`       // "jfr" | "collapsed" | "pprof"
-	Payload     string    `json:"payload"`      // Base64 인코딩 또는 텍스트 (collapsed)
-	Host        string    `json:"host"`
-	K8sPod      string    `json:"k8s_pod"`
-	K8sNode     string    `json:"k8s_node"`
-	K8sNamespace string   `json:"k8s_namespace"`
-	DurationMs  int64     `json:"duration_ms"`
-	SampledAt   time.Time `json:"sampled_at"`
+	ID           string    `json:"id"`
+	ServiceName  string    `json:"service_name"`
+	ProfileType  string    `json:"profile_type"` // "cpu" | "heap" | "wall" | "alloc"
+	Format       string    `json:"format"`       // "jfr" | "collapsed" | "pprof"
+	Payload      string    `json:"payload"`      // Base64 인코딩 또는 텍스트 (collapsed)
+	Host         string    `json:"host"`
+	K8sPod       string    `json:"k8s_pod"`
+	K8sNode      string    `json:"k8s_node"`
+	K8sNamespace string    `json:"k8s_namespace"`
+	DurationMs   int64     `json:"duration_ms"`
+	SampledAt    time.Time `json:"sampled_at"`
 }
 
 // ProfilingStore는 profiling_snapshots 테이블 CRUD를 담당한다.

--- a/internal/store/rca_store.go
+++ b/internal/store/rca_store.go
@@ -17,22 +17,22 @@ import (
 
 // RCAReport는 rca_reports 테이블의 단일 레코드다.
 type RCAReport struct {
-	ID               string    `json:"id"`
-	AnomalyID        string    `json:"anomaly_id"`
-	ServiceName      string    `json:"service_name"`
-	SpanName         string    `json:"span_name"`
-	AnomalyType      string    `json:"anomaly_type"`
-	Minute           time.Time `json:"minute"`
-	Severity         string    `json:"severity"`
-	ZScore           float64   `json:"z_score"`
-	CorrelatedSpans    string    `json:"correlated_spans"`    // JSON array
-	SimilarIncidents   string    `json:"similar_incidents"`   // JSON array
-	NearbyDeployments  string    `json:"nearby_deployments"`  // JSON array (GAP-04)
-	Hypothesis         string    `json:"hypothesis"`
-	LLMAnalysis      string    `json:"llm_analysis"`
-	Resolved         uint8     `json:"resolved"`
-	Feedback         string    `json:"feedback"`
-	CreatedAt        time.Time `json:"created_at"`
+	ID                string    `json:"id"`
+	AnomalyID         string    `json:"anomaly_id"`
+	ServiceName       string    `json:"service_name"`
+	SpanName          string    `json:"span_name"`
+	AnomalyType       string    `json:"anomaly_type"`
+	Minute            time.Time `json:"minute"`
+	Severity          string    `json:"severity"`
+	ZScore            float64   `json:"z_score"`
+	CorrelatedSpans   string    `json:"correlated_spans"`   // JSON array
+	SimilarIncidents  string    `json:"similar_incidents"`  // JSON array
+	NearbyDeployments string    `json:"nearby_deployments"` // JSON array (GAP-04)
+	Hypothesis        string    `json:"hypothesis"`
+	LLMAnalysis       string    `json:"llm_analysis"`
+	Resolved          uint8     `json:"resolved"`
+	Feedback          string    `json:"feedback"`
+	CreatedAt         time.Time `json:"created_at"`
 }
 
 // RCAStore는 rca_reports 테이블 조회/피드백 업데이트를 담당한다.

--- a/internal/store/slo.go
+++ b/internal/store/slo.go
@@ -37,9 +37,9 @@ type SLODefinition struct {
 type SLOBurnAlert struct {
 	ServiceName string    `json:"service_name"`
 	SLOName     string    `json:"slo_name"`
-	BurnRate    float64   `json:"burn_rate"`  // 실제 불량률 / 에러 예산
-	Window      string    `json:"window"`     // "1h" | "6h"
-	Severity    string    `json:"severity"`   // "page" | "ticket"
+	BurnRate    float64   `json:"burn_rate"` // 실제 불량률 / 에러 예산
+	Window      string    `json:"window"`    // "1h" | "6h"
+	Severity    string    `json:"severity"`  // "page" | "ticket"
 	AlertedAt   time.Time `json:"alerted_at"`
 }
 

--- a/internal/store/wal.go
+++ b/internal/store/wal.go
@@ -9,9 +9,10 @@
 //     — .tmp 파일로 쓰고 atomic rename해 데이터 손실 없이 교체
 //
 // 파일 레이아웃:
-//   {WALDir}/wal-traces.jsonl
-//   {WALDir}/wal-metrics.jsonl
-//   {WALDir}/wal-logs.jsonl
+//
+//	{WALDir}/wal-traces.jsonl
+//	{WALDir}/wal-metrics.jsonl
+//	{WALDir}/wal-logs.jsonl
 //
 // 장애 모드:
 //   - WAL 쓰기 실패 → 경고 로그만 남기고 메모리 저장은 계속 (graceful degradation)


### PR DESCRIPTION
## 변경 의도 (Why)
collector 프로젝트 코드 품질 개선. 범위는 세 가지로 합의:
1. **gofmt 정렬** — 19개 파일이 gofmt-clean 상태가 아님 (CI 위생)
2. **무시된 에러 검토** — `_ =` 105곳 검토
3. **테스트 추가** — 테스트 없는 패키지 보강

거대 파일 분할(clickhouse.go/http.go)은 회귀 위험이 커 이번 범위에서 제외.

## 변경 내용 (What)
- **gofmt -w (19 files)**: 주석/구조체 필드 정렬. Go 1.19+ doc-comment 정규화 포함 (`wal.go` 코드블록, `clickhouse.go`)
- **clickhouse.go 주석 1줄 재작성**: `QueryBrokenTraces` doc 주석에서 gofmt가 `''`(빈 문자열 표기)를 곡선 따옴표 `”`로 바꿔 의미가 흐려짐 → `빈 문자열(empty string)` 표현으로 변경해 의미 보존 + gofmt 안정화
- **신규 `internal/processor/cardinality_test.go`**: 단위 테스트 6개
  - 블룸 필터 add/test
  - per-(service, attr_key) 한도 동작
  - 고카디널리티 값 placeholder 치환
  - 비문자열 값 통과(미치환)
  - service/key별 트래커 격리
  - metrics/logs 경로

## 검증 결과 (Verify)
- `go build ./...` ✅
- `go vet ./...` ✅
- `gofmt -l .` → clean ✅
- `go test -race -count=1 ./...` → 전부 통과, 신규 테스트 6개 PASS ✅

## 위험 요소 (Risk)
- **낮음**. gofmt 변경은 동작 불변(`git diff -w`로 비공백 변경이 doc-주석 정규화뿐임을 확인). 테스트는 추가만. 프로덕션 로직 변경 0.

## 검토 결과 메모
- **무시된 에러 105곳**: 전부 정당하게 무시됨 → 변경 없음.
  - `json.Encode`(67, HTTP 응답 스트림), `hash.Write`/`crypto/rand.Read`(계약상 에러 미반환), `Close`/`os.Remove`(cleanup 경로)
  - `kafka.WriteMessages`(4): Async 모드라 항상 nil 반환 + 기존 `ErrorLogger`가 비동기 전송 실패를 이미 로깅. `Completion` 콜백 추가는 중복이라 보류.