### PR TITLE
ci: AGENTS.md 미러링 추가 (codex)

### DIFF
--- a/.github/workflows/sync-claudemd.yml
+++ b/.github/workflows/sync-claudemd.yml
@@ -3,6 +3,7 @@ name: Keep CLAUDE.md in sync with PR
 # main 대상 PR 이 열리거나 새 커밋이 푸시될 때 동작.
 # ① 기계적 구간: 스크립트가 재생성 (AI 불필요)
 # ② 판단 구간: Claude 가 diff 보고 서술형 내용만 갱신
+# ③ AGENTS.md 미러: CLAUDE.md 를 codex 용 AGENTS.md 로 복사 (마커 있을 때만)
 # 결과를 같은 PR 브랜치에 커밋한다.
 on:
   pull_request:
@@ -55,7 +56,6 @@ jobs:
         if: steps.guard.outputs.skip != 'true' && steps.exists.outputs.ok == 'true'
         env:
           # Pro/Max 구독 토큰으로 인증 (claude setup-token 으로 발급).
-          # API 크레딧 대신 구독 한도를 사용한다.
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           claude -p "이 브랜치가 origin/main 대비 바꾼 내용을 'git diff origin/main...HEAD' 로 확인하라.
@@ -66,13 +66,26 @@ jobs:
           CLAUDE.md 외의 어떤 파일도 수정하지 마라." \
             --allowedTools "Read,Edit,Bash(git diff:*),Bash(git log:*)"
 
-      # ── ①+② 결과를 같은 PR 브랜치에 커밋 ──
+      # ── ③ AGENTS.md 미러 (codex용): 마커 있는 경우에만 CLAUDE.md 복사 ──
+      - name: AGENTS.md 미러링
+        if: steps.guard.outputs.skip != 'true' && steps.exists.outputs.ok == 'true'
+        run: |
+          M="<!-- AUTO-MIRROR of CLAUDE.md — 직접 수정 금지 (codex/AGENTS.md) -->"
+          if [ -f AGENTS.md ] && [ "$(head -n1 AGENTS.md)" = "$M" ]; then
+            { printf '%s\n\n' "$M"; cat CLAUDE.md; } > AGENTS.md
+            echo "AGENTS.md 미러링 완료"
+          else
+            echo "AGENTS.md 미러 대상 아님(마커 없음/파일 없음) → 생략"
+          fi
+
+      # ── 결과를 같은 PR 브랜치에 커밋 ──
       - name: 변경됐으면 커밋
         if: steps.guard.outputs.skip != 'true' && steps.exists.outputs.ok == 'true'
         run: |
-          git diff --quiet -- CLAUDE.md && { echo "변경 없음"; exit 0; }
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add CLAUDE.md
-          git commit -m "docs: PR 변경 반영해 CLAUDE.md 갱신 [claude-docs]"
+          [ -f AGENTS.md ] && git add AGENTS.md
+          if git diff --cached --quiet; then echo "변경 없음"; exit 0; fi
+          git commit -m "docs: PR 변경 반영해 CLAUDE.md/AGENTS.md 갱신 [claude-docs]"
           git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ javi 관측 데이터 수집기. 들어온 텔레메트리를 처리해 **ClickH
 
 > 코딩 컨벤션·주의사항을 여기에 적어두세요. PR로 코드가 바뀌면 이 영역은 GitHub Actions(Claude)가 자동 보강합니다.
 
+- `AGENTS.md`는 codex용으로 CI가 CLAUDE.md를 그대로 복사하는 미러 파일입니다(파일 상단에 `<!-- AUTO-MIRROR -->` 마커가 있을 때만 동작). 내용을 바꾸려면 CLAUDE.md를 수정하세요, AGENTS.md를 직접 고치지 마세요.
+
 <!-- AUTO-GENERATED:start (스크립트가 관리. 직접 수정 금지) -->
 
 _아래 구간은 스크립트가 자동 생성합니다. 직접 수정하지 마세요._

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+<!-- AUTO-MIRROR of CLAUDE.md — 직접 수정 금지 (codex/AGENTS.md) -->
+
+# javi-collector
+
+javi 관측 데이터 수집기. 들어온 텔레메트리를 처리해 **ClickHouse**에 저장하고, **RAG**(Qdrant + Ollama) 파이프라인과 연동되는 Go 서비스.
+
+## 아키텍처
+
+- `cmd/` — 실행 진입점
+- `internal/` — 수집·처리·저장 내부 패키지(HTTP 서버 등)
+- `docker/` — 컨테이너 구성
+- `scripts/` — 보조 스크립트
+- module: `github.com/kkc/javi-collector`
+- 저장소: ClickHouse / 벡터: Qdrant / 임베딩·LLM: Ollama
+
+## 개발 명령 (Makefile)
+
+- 실행: `make run` / `run-dev` / `run-prod` / `run-sampling`, `make dev`
+- 빌드/테스트/린트: `make build` / `make test` / `make lint`
+- 도커: `make docker-up` / `docker-down` / `docker-build`
+- 쿠버네티스: `make k8s-apply` / `k8s-rollout` / `k8s-status` / `k8s-logs` / `k8s-delete`
+- 포트포워딩: `make ch-port-forward` / `qdrant-port-forward` / `ollama-port-forward`
+- RAG 통합 테스트: `make k8s-rag-test*`
+
+## 규칙·관례
+
+> 코딩 컨벤션·주의사항을 여기에 적어두세요. PR로 코드가 바뀌면 이 영역은 GitHub Actions(Claude)가 자동 보강합니다.
+
+<!-- AUTO-GENERATED:start (스크립트가 관리. 직접 수정 금지) -->
+
+_아래 구간은 스크립트가 자동 생성합니다. 직접 수정하지 마세요._
+
+### 기술 스택
+- Go (`go.mod`)
+- Docker (`Dockerfile`)
+
+### 명령어
+**Make 타깃**:
+```
+build
+ch-port-forward
+clean
+dev
+docker-build
+docker-down
+docker-up
+k8s-apply
+k8s-apply-ch
+k8s-delete
+k8s-logs
+k8s-rag-test
+k8s-rag-test-all
+k8s-rag-test-integration
+k8s-rollout
+k8s-status
+lint
+ollama-port-forward
+qdrant-port-forward
+run
+run-dev
+run-prod
+run-sampling
+test
+```
+
+### 최상위 디렉터리 구조
+```
+.github
+cmd
+docker
+internal
+scripts
+```
+
+<!-- AUTO-GENERATED:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ javi 관측 데이터 수집기. 들어온 텔레메트리를 처리해 **ClickH
 
 > 코딩 컨벤션·주의사항을 여기에 적어두세요. PR로 코드가 바뀌면 이 영역은 GitHub Actions(Claude)가 자동 보강합니다.
 
+- `AGENTS.md`는 codex용으로 CI가 CLAUDE.md를 그대로 복사하는 미러 파일입니다(파일 상단에 `<!-- AUTO-MIRROR -->` 마커가 있을 때만 동작). 내용을 바꾸려면 CLAUDE.md를 수정하세요, AGENTS.md를 직접 고치지 마세요.
+
 <!-- AUTO-GENERATED:start (스크립트가 관리. 직접 수정 금지) -->
 
 _아래 구간은 스크립트가 자동 생성합니다. 직접 수정하지 마세요._


### PR DESCRIPTION
CLAUDE.md를 codex용 AGENTS.md로 자동 미러링. 마커 있는 AGENTS.md만 갱신(직접 작성본 보호). 머지 후 PR마다 두 파일이 동기화됩니다.